### PR TITLE
gralloc: Fix RAW10/12 buffer alignment for trinket

### DIFF
--- a/gralloc/Android.mk
+++ b/gralloc/Android.mk
@@ -31,6 +31,10 @@ else ifeq ($(TARGET_USES_YCRCB_VENUS_CAMERA_PREVIEW),true)
     LOCAL_CFLAGS              += -DUSE_YCRCB_CAMERA_PREVIEW_VENUS
 endif
 
+ifeq ($(TARGET_NEEDS_RAW10_BUFFER_FIX),true)
+LOCAL_CFLAGS                  += -DRAW10_BUFFER_FIX
+endif
+
 LOCAL_ADDITIONAL_DEPENDENCIES := $(common_deps) $(kernel_deps)
 LOCAL_SRC_FILES               := gr_ion_alloc.cpp \
                                  gr_allocator.cpp \

--- a/gralloc/gr_utils.cpp
+++ b/gralloc/gr_utils.cpp
@@ -741,10 +741,18 @@ void GetAlignedWidthAndHeight(const BufferInfo &info, unsigned int *alignedw,
       aligned_w = ALIGN(width, 16);
       break;
     case HAL_PIXEL_FORMAT_RAW12:
+#ifdef RAW10_BUFFER_FIX
       aligned_w = ALIGN(width * 12 / 8, 8);
+#else
+      aligned_w = ALIGN(width * 12 / 8, 8);
+#endif
       break;
     case HAL_PIXEL_FORMAT_RAW10:
+#ifdef RAW10_BUFFER_FIX
       aligned_w = ALIGN(width * 10 / 8, 8);
+#else
+      aligned_w = ALIGN(width * 10 / 8, 8);
+#endif
       break;
     case HAL_PIXEL_FORMAT_RAW8:
       aligned_w = ALIGN(width, 8);


### PR DESCRIPTION
[Vishalcj17] Guard with TARGET_NEEDS_RAW10_BUFFER_FIX
Signed-off-by: Vishalcj17 <vishalcj@aospa.co>
Change-Id: Ic70b21180d7c8441bf794a08405fe4428a42d8ec